### PR TITLE
fix cwd to absolute path when current directory is not at root, make perl 5.26 compliant

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,3 +1,4 @@
+use lib '.';
 use inc::Module::Install;
 
 name            'Test-Mock-Net-FTP';

--- a/lib/Test/Mock/Net/FTP.pm
+++ b/lib/Test/Mock/Net/FTP.pm
@@ -400,6 +400,11 @@ sub mock_default_cwd {
         $dirs = "";
     }
 
+    # if an absolute path, start at root
+    elsif ( $dirs =~ m|^/| ) {
+        $self->{mock_cwd} = rootdir();
+    }
+
     my $backup_cwd = $self->_mock_cwd;
     for my $dir ( splitdir($dirs) ) {
         $self->_mock_cwd_each($dir);

--- a/t/003_cwd.t
+++ b/t/003_cwd.t
@@ -1,6 +1,7 @@
 #!/usr/bin/perl -w
 use Test::More;
 use Test::Mock::Net::FTP;
+use lib '.';
 use t::Util;
 use strict;
 use warnings;

--- a/t/003_cwd.t
+++ b/t/003_cwd.t
@@ -100,16 +100,38 @@ subtest 'chdir to up another dir', sub {
     done_testing();
 };
 
-subtest 'using absolute path', sub {
-    my $ftp = prepare_ftp();
+subtest 'absolute path', sub {
 
-    ok( $ftp->cwd('/ftproot/dir1/dir2') );
-    is( $ftp->pwd, '/ftproot/dir1/dir2' );
-    is( abs2rel($ftp->mock_pwd), 'tmp/ftpserver/dir1/dir2' );
+    subtest 'starting at root' => sub {
+        my $ftp = prepare_ftp();
 
-    $ftp->quit();
-    done_testing();
+        ok( $ftp->cwd('/ftproot/dir1/dir2') );
+        is( $ftp->pwd, '/ftproot/dir1/dir2' );
+        is( abs2rel($ftp->mock_pwd), 'tmp/ftpserver/dir1/dir2' );
+
+        $ftp->quit();
+        done_testing();
+    };
+
+
+    subtest 'starting below root', sub {
+
+        my $ftp = prepare_ftp();
+
+        ok( $ftp->cwd('dir1/dir2') );
+        is( $ftp->pwd, '/ftproot/dir1/dir2' );
+
+        ok( $ftp->cwd('/ftproot/dir1/dir2') );
+        is( $ftp->pwd, '/ftproot/dir1/dir2' );
+
+        is( abs2rel($ftp->mock_pwd), 'tmp/ftpserver/dir1/dir2' );
+
+        $ftp->quit();
+        done_testing();
+    };
+
 };
+
 
 
 subtest 'invalid path', sub {

--- a/t/004_put.t
+++ b/t/004_put.t
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use Test::More;
 use File::Spec::Functions qw(catfile catdir rootdir);
+use lib '.';
 use t::Util;
 use Test::Mock::Net::FTP;
 use Cwd;

--- a/t/005_get.t
+++ b/t/005_get.t
@@ -5,6 +5,7 @@ use Test::More;
 
 use File::Copy;
 use File::Spec::Functions qw(catfile);
+use lib '.';
 use t::Util;
 use Test::Mock::Net::FTP;
 use Cwd;

--- a/t/006_intercept_put.t
+++ b/t/006_intercept_put.t
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use Test::More;
 use File::Spec::Functions qw(catfile);
+use lib '.';
 use t::Util;
 use Test::Mock::Net::FTP qw(intercept);
 

--- a/t/007_intercept_get.t
+++ b/t/007_intercept_get.t
@@ -7,6 +7,7 @@ use File::Path qw(remove_tree make_path);
 use File::Copy;
 use File::Spec::Functions qw(catfile catdir);
 use Cwd qw(chdir getcwd);
+use lib '.';
 use t::Util;
 use Test::Mock::Net::FTP qw(intercept);
 use Net::FTP;

--- a/t/008_override.t
+++ b/t/008_override.t
@@ -1,6 +1,7 @@
 #!/usr/bin/perl -w
 use strict;
 use warnings;
+use lib '.';
 use t::Util;
 use Test::More;
 

--- a/t/009_ls.t
+++ b/t/009_ls.t
@@ -7,6 +7,7 @@ use File::Copy;
 use File::Spec::Functions qw(catfile);
 
 use Test::More;
+use lib '.';
 use t::Util;
 use Test::Mock::Net::FTP;
 

--- a/t/010_dir.t
+++ b/t/010_dir.t
@@ -7,6 +7,7 @@ use File::Path qw(remove_tree make_path);
 use File::Copy;
 use File::Spec::Functions qw(catfile catdir);
 use Test::More;
+use lib '.';
 use t::Util;
 use Test::Mock::Net::FTP;
 

--- a/t/011_misc_methods.t
+++ b/t/011_misc_methods.t
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 
 use Test::More;
+use lib '.';
 use t::Util;
 use Test::Mock::Net::FTP;
 use File::Spec::Functions qw(catfile);

--- a/t/012_rename.t
+++ b/t/012_rename.t
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use Test::More;
 use File::Spec::Functions qw(catfile);
+use lib '.';
 use t::Util;
 use Test::Mock::Net::FTP;
 

--- a/t/013_delete.t
+++ b/t/013_delete.t
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use Test::More;
 use File::Spec::Functions qw(catfile);
+use lib '.';
 use t::Util;
 use Test::Mock::Net::FTP;
 

--- a/t/014_mkdir_and_rmdir.t
+++ b/t/014_mkdir_and_rmdir.t
@@ -4,6 +4,7 @@ use warnings;
 use Test::More;
 use File::Path qw(remove_tree);
 use File::Spec::Functions qw(catdir);
+use lib '.';
 use t::Util;
 use Test::Mock::Net::FTP;
 

--- a/t/015_append.t
+++ b/t/015_append.t
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use Test::More;
 use File::Spec::Functions qw(catfile catdir rootdir);
+use lib '.';
 use t::Util;
 use Test::Mock::Net::FTP;
 use Cwd;

--- a/t/016_clear_message.t
+++ b/t/016_clear_message.t
@@ -1,6 +1,7 @@
 #!/usr/bin/perl -w
 use strict;
 use warnings;
+use lib '.';
 use t::Util;
 use Test::More;
 

--- a/t/017_command_history.t
+++ b/t/017_command_history.t
@@ -1,6 +1,7 @@
 #!/usr/bin/perl -w
 use strict;
 use warnings;
+use lib '.';
 use t::Util;
 use Test::More;
 

--- a/t/018_default_implementation.t
+++ b/t/018_default_implementation.t
@@ -1,6 +1,7 @@
 #!/usr/bin/perl -w
 use strict;
 use warnings;
+use lib '.';
 use t::Util;
 use Test::More;
 


### PR DESCRIPTION
When changing directory to an absolute path, if the current directory was not at the ftp root, it would append the segments of the new path to the current directory path instead of the ftp root.

Perl 5.26 will not include '.' by default in @INC for security reasons.  I've sprinkled some
`use lib '.';` statements where required to get it to compile under the latest developer version of Perl (5.25.12).